### PR TITLE
SCAN-5585 : Use valid ref for pull_request event

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -60,9 +60,3 @@ runs:
         yq e ".runs.image = env(IMAGE_TAG)" -i action.yml
         git add action.yml
         git diff-index --quiet HEAD || (git commit -m "[Auto] Image tag updated latest pushed version" && git push)
-   
-
-    
-
-
-    

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -1,0 +1,68 @@
+name: build-and-deploy-image
+
+inputs:
+  registry:
+    description: The registry to deploy to
+    required: true
+  image_name:
+    description: The name of the docker image
+    required: true
+  username:
+    description: The username to login to the container registry
+    required: true
+  password:
+    description: The password to login to the container registry
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image_name }}
+        tags: type=sha,format=long
+
+    - name: Build and push Docker image
+      id: push
+      uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+    
+    - name: install yq
+      shell: bash
+      run: |
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
+        sudo add-apt-repository ppa:rmescandon/yq -y
+        sudo apt update -y
+        sudo apt install yq -y
+
+    - name: Commit changes
+      shell: bash
+      env:
+        IMAGE_TAG: docker://${{ steps.meta.outputs.tags }}
+      run: |
+        git config --global user.name 'Github'
+        git config --global user.email 'github@users.noreply.github.com'
+
+        yq e ".runs.image = env(IMAGE_TAG)" -i action.yml
+        git add action.yml
+        git diff-index --quiet HEAD || (git commit -m "[Auto] Image tag updated latest pushed version" && git push)
+   
+
+    
+
+
+    

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,15 @@ on:
     branches:
       - 'main'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 permissions:
   contents: write
+  packages: write
+  checks: write
+  id-token: write
 
 jobs:
   lint:
@@ -22,16 +29,20 @@ jobs:
     needs: [ lint ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Build local scanner action image
-        run: |
-          docker build .
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-image
+        name: Build and publish docker image
+        with:
+          registry: ${{ env.REGISTRY }}
+          image_name: ${{ env.IMAGE_NAME }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   verify-action:
     runs-on: ubuntu-latest
     needs: [ build-action-docker-image ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses : ./
         name: Run action against itself
         with:
@@ -47,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ verify-action ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install modules
         run: npm ci
       - name: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,8 @@ jobs:
     needs: [ build-action-docker-image ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
       - uses : ./
         name: Run action against itself
         with:
@@ -59,6 +61,8 @@ jobs:
     needs: [ verify-action ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
       - name: Install modules
         run: npm ci
       - name: release

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,15 +6,21 @@ on:
     - '*'
     - '!main'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 permissions:
-  contents: read
+  contents: write
+  packages: write
   checks: write
+  id-token: write
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install modules
         run: npm ci
       - name: eslint
@@ -24,16 +30,20 @@ jobs:
     needs: [ lint ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Build local scanner action image
-        run: |
-          docker build .
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-image
+        name: Build and publish docker image
+        with:
+          registry: ${{ env.REGISTRY }}
+          image_name: ${{ env.IMAGE_NAME }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
   
   verify-action:
     runs-on: ubuntu-latest
     needs: [ build-action-docker-image ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses : ./
         name: Run action against repoository
         with:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -44,6 +44,8 @@ jobs:
     needs: [ build-action-docker-image ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
       - uses : ./
         name: Run action against repoository
         with:

--- a/action.yml
+++ b/action.yml
@@ -71,4 +71,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-ff0a63a22c9c93d850d6cab1a191217efdc017ae'
+  image: 'docker://ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-1e80aee683cc8c46df31721f51c2e20694bee9a0'

--- a/action.yml
+++ b/action.yml
@@ -71,4 +71,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-1e80aee683cc8c46df31721f51c2e20694bee9a0'
+  image: 'docker://ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-b7a1dffe420986146e9b8f1108dc48156850cf20'

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: crosshair
   color: green
 inputs:
-  apiUrl:  # id of input
+  apiUrl: # id of input
     description: Url of your contrast instance, defaults to https://app.contrastsecurity.com/
     required: true
     default: 'https://app.contrastsecurity.com/'
@@ -22,8 +22,8 @@ inputs:
     required: true
   checks:
     description: >
-      If set, checks will be added to the current commit based on any vulnerabilities found.
-      Requires the 'checks: write' permission.
+      If set, checks will be added to the current commit based on any vulnerabilities found. Requires the 'checks: write' permission.
+
     required: false
     default: false
   codeQuality:
@@ -32,8 +32,8 @@ inputs:
     default: false
   defaultBranch:
     description: >
-      Set this to true or false explicitly override the default branching behviour in scan whereby scan results
-      not on the default github branch are not saved against the main project.
+      Set this to true or false explicitly override the default branching behviour in scan whereby scan results not on the default github branch are not saved against the main project.
+
     required: false
   label:
     description: Label to associate with the current scan. Defaults to the current ref e.g. refs/heads/main
@@ -51,14 +51,14 @@ inputs:
     required: false
   strategy:
     description: >
-      Used in conjuction with severity or checks, set this valid to fail the build based on agreggated project
-      vulnerabilities or scan level. Valid values are "project" or "scan". Defaults to "project".
+      Used in conjuction with severity or checks, set this valid to fail the build based on agreggated project vulnerabilities or scan level. Valid values are "project" or "scan". Defaults to "project".
+
     required: false
     default: "project"
   severity:
     description: >
-      Set this to cause the build to fail if vulnerabilities are found exceeding this severity or higher.
-      Valid values are CRITICAL, HIGH, MEDIUM, LOW, NOTE.
+      Set this to cause the build to fail if vulnerabilities are found exceeding this severity or higher. Valid values are CRITICAL, HIGH, MEDIUM, LOW, NOTE.
+
     required: false
   timeout:
     description: Execution timeout (in seconds) setting passed to the underlying scan engine. Defaulted to 60 minutes.
@@ -66,8 +66,9 @@ inputs:
   token:
     description: >
       GitHub token for GitHub API requests. Defaults to GITHUB_TOKEN.
+
     required: true
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-ff0a63a22c9c93d850d6cab1a191217efdc017ae'

--- a/action.yml
+++ b/action.yml
@@ -71,4 +71,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-b7a1dffe420986146e9b8f1108dc48156850cf20'
+  image: 'docker://ghcr.io/contrast-security-oss/contrast-local-scan-action:sha-a35e9fa66981020851b41fcf588f300388c9c3b1'

--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,7 @@ const ref = getRef();
 const label = core.getInput("label") || ref;
 
 // Pinning the local scanner version
-const localScannerVersion = "1.0.10";
+const localScannerVersion = "1.1.1";
 
 const memory = core.getInput("memory");
 const path = core.getInput("path") || process.env.GITHUB_WORKSPACE;

--- a/src/config.js
+++ b/src/config.js
@@ -1,13 +1,33 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
 
+const PULL_REQUEST_EVENT = 'pull_request';
+const WORKFLOW_DISPATCH = 'workflow_dispatch';
+const PUSH_EVENT = 'push';
 const DEFAULT_BRANCH_NAME = github.context.payload?.repository?.default_branch;
 
-const thisBranchName = () => {
-  core.info('Checking branch name');
-  core.info(JSON.stringify(github.context.payload, null, 2));
+const getRef = () => {
 
-  const refParts = github.context.payload.ref.split('/');
+  switch (github.context.eventName) {
+    case PULL_REQUEST_EVENT: {
+      return github.context.payload?.pull_request?.head?.ref;
+    }
+    case PUSH_EVENT:
+    case WORKFLOW_DISPATCH: {
+      return github.context.payload?.ref;
+    }
+    default: {
+      core.warning(`Received unexpected github event ${github.context.eventName}`);
+      return github.context.payload?.ref;
+    }
+  }
+};
+
+const thisBranchName = () => {
+
+  const ref = getRef();
+
+  const refParts = ref.split('/');
 
   return refParts[refParts.length-1];
 };
@@ -43,7 +63,8 @@ const checks = core.getBooleanInput("checks");
 const codeQuality = core.getBooleanInput("codeQuality");
 const defaultBranch = isDefaultBranch();
 
-const label = core.getInput("label") || process.env.GITHUB_REF;
+const ref = getRef();
+const label = core.getInput("label") || ref;
 
 // Pinning the local scanner version
 const localScannerVersion = "1.0.10";
@@ -52,7 +73,7 @@ const memory = core.getInput("memory");
 const path = core.getInput("path") || process.env.GITHUB_WORKSPACE;
 const projectName =
   core.getInput("projectName") || process.env.GITHUB_REPOSITORY;
-const ref = process.env.GITHUB_REF;
+
 const resourceGroup = core.getInput("resourceGroup");
 const severity = core.getInput("severity")?.toLowerCase() || undefined;
 const strategy = core.getInput("strategy") || "project";
@@ -63,6 +84,7 @@ const token = core.getInput("token");
 core.debug(`Default branch name : ${DEFAULT_BRANCH_NAME}`);
 core.debug(`This branch name : ${thisBranchName()}`);
 core.debug(`Default branch resolved setting : ${defaultBranch}`)
+core.debug(JSON.stringify(github.context, null, 2));
 
 module.exports = {
   apiUrl,

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,9 @@ const github = require("@actions/github");
 const DEFAULT_BRANCH_NAME = github.context.payload?.repository?.default_branch;
 
 const thisBranchName = () => {
+  core.info('Checking branch name');
+  core.info(JSON.stringify(github.context.payload, null, 2));
+
   const refParts = github.context.payload.ref.split('/');
 
   return refParts[refParts.length-1];

--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,7 @@ const ref = getRef();
 const label = core.getInput("label") || ref;
 
 // Pinning the local scanner version
-const localScannerVersion = "1.1.1";
+const localScannerVersion = "1.1.2";
 
 const memory = core.getInput("memory");
 const path = core.getInput("path") || process.env.GITHUB_WORKSPACE;

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,9 @@ async function runScan() {
 async function runScanWithChecks() {
   let scanDetails;
 
-  try {
-    await startCheck();
+  await startCheck();
 
+  try {
     scanDetails = await runScan();
 
     core.debug(JSON.stringify(scanDetails, null, 2));


### PR DESCRIPTION
### Description

- Fixing error on pull_request events whereby the ref used to create a scan label is in a different place in the event payload.
- Adding a better warning when the checks: write permission is not set.
- Pre-building the docker image and publishing to ghcr.io and using this in the action, to avoid building the image on each action run.