### PR TITLE
Reference @v1 tag in README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ up. After which, complete the following steps:
          runs-on: ubuntu-latest
          steps:
            - uses: actions/checkout@v3
-           - uses: Contrast-Security-OSS/contrast-local-scan-action@v1.0.9
+           - uses: Contrast-Security-OSS/contrast-local-scan-action@v1
              with:
                apiUrl: ${{ secrets.CONTRAST__API__URL }}
                apiUserName: ${{ secrets.CONTRAST__API__USER_NAME }}
@@ -87,7 +87,7 @@ up. After which, complete the following steps:
      runs-on: ubuntu-latest
        steps:
          - uses: actions/checkout@v3
-         - uses: Contrast-Security-OSS/contrast-local-scan-action@v1.0.0
+         - uses: Contrast-Security-OSS/contrast-local-scan-action@v1
          with:
            apiUrl: ${{ secrets.CONTRAST__API__URL }}
            apiUserName: ${{ secrets.CONTRAST__API__USER_NAME }}


### PR DESCRIPTION
Use the @v1 tag in the README snippets as folks copy these when doing setup.